### PR TITLE
file-class case mismatch fixed

### DIFF
--- a/Form/JQuery/Type/Select2TimeZoneType.php
+++ b/Form/JQuery/Type/Select2TimeZoneType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\Options;
  * @author Chris Tickner <chris.tickner@gmail.com>
  * @author Benjamin Schumacher <benschumi@hotmail.fr>
  */
-class Select2TimezoneType extends AbstractType
+class Select2TimeZoneType extends AbstractType
 {
     private $configs;
 


### PR DESCRIPTION
Case mismatch between loaded and declared class names: Genemu\Bundle\FormBundle\Form\JQuery\Type\Select2TimeZoneType vs Genemu\Bundle\FormBundle\Form\JQuery\Type\Select2TimezoneType